### PR TITLE
Add some missing `@Override` annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@
   - Code navigation is Not Implement Yet
 
 ### Changed
-- Move changelog from `README.md` to `CHANGELOG.md`  
+- Move changelog from `README.md` to `CHANGELOG.md` 
+- Add some missing `@Override` annotations in `ConfigurationOptions.java`(And it seems that SequenceDiagram support the 
+  2021.1 IDEA platform now ?)
 
 ## [2.0.6]
 ### Fixed

--- a/build.gradle
+++ b/build.gradle
@@ -32,9 +32,10 @@ publishPlugin {
 }
 
 group 'vanstudio'
-version '2.1.a1'
+version '2.1.a2'
 
-sourceCompatibility = 1.8
+//some jdk11 functions in codes
+sourceCompatibility = 11
 
 tasks.withType(JavaCompile) { options.encoding = 'UTF-8' }
 

--- a/src/main/java/org/intellij/sequencer/config/ConfigurationOptions.java
+++ b/src/main/java/org/intellij/sequencer/config/ConfigurationOptions.java
@@ -11,32 +11,39 @@ public class ConfigurationOptions implements SearchableConfigurable {
     private ConfigurationUI _configurationUI;
     private Configuration configuration;
 
+    @Override
     public String getDisplayName() {
         return "Sequence Diagram";
     }
 
+    @Override
     public String getHelpTopic() {
         return null;
     }
 
+    @Override
     public JComponent createComponent() {
         configuration = Configuration.getInstance();
         return getForm().getMainPanel();
     }
 
+    @Override
     public boolean isModified() {
         return getForm().isModified(configuration);
     }
 
+    @Override
     public void apply() {
         getForm().apply(configuration);
         fireConfigChanged();
     }
 
+    @Override
     public void reset() {
         getForm().reset(configuration);
     }
 
+    @Override
     public void disposeUIResources() {
 
     }


### PR DESCRIPTION
Yesterday I update my IDEA to version 2021.1, and I found `Sequence Diagram` has crashed.

```
Cannot create configurable

com.intellij.diagnostic.PluginException: Cannot create class org.intellij.sequencer.config.ConfigurationOptions (classloader=PluginClassLoader(plugin=PluginDescriptor(name=SequenceDiagram, id=SequenceDiagram, descriptorPath=plugin.xml, path=~\AppData\Roaming\JetBrains\IdeaIC2021.1\plugins\SequenceDiagram, version=1.3.0, package=null), packagePrefix=null, instanceId=37, state=active))
	......
Caused by: java.lang.NoSuchMethodException: org.intellij.sequencer.config.ConfigurationOptions.<init>()
	at java.base/java.lang.Class.getConstructor0(Class.java:3349)
	at java.base/java.lang.Class.getDeclaredConstructor(Class.java:2553)
	at com.intellij.serviceContainer.ComponentManagerImpl.instantiateClass(ComponentManagerImpl.kt:720)
	... 47 more
```


I follow exception message to `org.intellij.sequencer.config.ConfigurationOptions`,  add a few `@Override` annotations and rebuild a jar. Now `Sequence Diagram` can work on my pc.